### PR TITLE
Fix calculate bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
 
     <!-- Version Tag -->
     <div class="mt-4 text-center text-gray-500 text-xs">
-      Version 1.4
+      Version 1.6
     </div>
   </div>
 
@@ -396,7 +396,14 @@
     }
 
     // 5) Helper: render the final results table (with year-over-year changes)
-    function renderWithDiff(taxY0, taxY1, taxY2, taxY3, taxY4) {
+    function renderWithDiff(taxY0, taxY1, taxY2, taxY3, taxY4, rates) {
+      const {
+        councilY0,
+        councilY1,
+        councilY2,
+        councilY3,
+        councilY4
+      } = rates;
       const diffY1 = taxY1 - taxY0;
       const pctY1  = (diffY1 / taxY0) * 100;
       const diffY2 = taxY2 - taxY1;
@@ -414,7 +421,7 @@
               GL 2023<br /><span class="text-gray-500">(billed in 2024)</span>
             </div>
             <div class="text-right text-gray-700">
-              ${councilY0.toFixed(2)} mills<br /><span class="text-gray-500">actual</span>
+              ${Number(councilY0).toFixed(2)} mills<br /><span class="text-gray-500">actual</span>
             </div>
             <div class="text-right text-gray-700">$${formatCurrency(taxY0)}</div>
           </div>
@@ -423,7 +430,7 @@
               GL 2024<br /><span class="text-gray-500">(billed in 2025)</span>
             </div>
             <div class="text-right text-gray-700">
-              ${councilY1.toFixed(2)} mills<br /><span class="text-gray-500">actual</span>
+              ${Number(councilY1).toFixed(2)} mills<br /><span class="text-gray-500">actual</span>
             </div>
             <div class="text-right text-gray-700">$${formatCurrency(taxY1)}</div>
           </div>
@@ -432,7 +439,7 @@
               GL 2025<br /><span class="text-gray-500">(billed in 2026)</span>
             </div>
             <div class="text-right text-gray-700">
-              ${councilY2.toFixed(2)} mills<br /><span class="text-gray-500">est.</span>
+              ${Number(councilY2).toFixed(2)} mills<br /><span class="text-gray-500">est.</span>
             </div>
             <div class="text-right text-gray-700">$${formatCurrency(taxY2)}</div>
           </div>
@@ -441,7 +448,7 @@
               GL 2026<br /><span class="text-gray-500">(billed in 2027)</span>
             </div>
             <div class="text-right text-gray-700">
-              ${councilY3.toFixed(2)} mills<br /><span class="text-gray-500">est.</span>
+              ${Number(councilY3).toFixed(2)} mills<br /><span class="text-gray-500">est.</span>
             </div>
             <div class="text-right text-gray-700">$${formatCurrency(taxY3)}</div>
           </div>
@@ -450,7 +457,7 @@
               GL 2027<br /><span class="text-gray-500">(billed in 2028)</span>
             </div>
             <div class="text-right text-gray-700">
-              ${councilY4.toFixed(2)} mills<br /><span class="text-gray-500">est.</span>
+              ${Number(councilY4).toFixed(2)} mills<br /><span class="text-gray-500">est.</span>
             </div>
             <div class="text-right text-gray-700">$${formatCurrency(taxY4)}</div>
           </div>
@@ -553,7 +560,13 @@
       const taxY4 = millY4 * councilY4; // GL 2027
 
       // Render everything with year-over-year comparisons
-      renderWithDiff(taxY0, taxY1, taxY2, taxY3, taxY4);
+      renderWithDiff(taxY0, taxY1, taxY2, taxY3, taxY4, {
+        councilY0,
+        councilY1,
+        councilY2,
+        councilY3,
+        councilY4
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- ensure council mill rates are cast to numbers before calling `toFixed`
- bump version to 1.6

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684756e1246883288d11d9813d741e23